### PR TITLE
[Phase 0] M0.3: LSP初期化ハンドシェイクを実装

### DIFF
--- a/lsp-core/src/main/java/com/groovylsp/presentation/server/GroovyLanguageServer.java
+++ b/lsp-core/src/main/java/com/groovylsp/presentation/server/GroovyLanguageServer.java
@@ -5,6 +5,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
@@ -37,6 +38,13 @@ public class GroovyLanguageServer implements LanguageServer, LanguageClientAware
 
     InitializeResult result = new InitializeResult(capabilities);
     return CompletableFuture.completedFuture(result);
+  }
+
+  @Override
+  public void initialized(InitializedParams params) {
+    // Called after the client received the InitializeResult but before any other
+    // requests/notifications
+    // This is where we can register dynamic capabilities and perform any post-initialization setup
   }
 
   @Override

--- a/lsp-core/src/test/java/com/groovylsp/integration/LanguageServerIntegrationTest.java
+++ b/lsp-core/src/test/java/com/groovylsp/integration/LanguageServerIntegrationTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,6 +54,10 @@ class LanguageServerIntegrationTest {
     // Then
     assertNotNull(initResult);
     assertNotNull(initResult.getCapabilities());
+
+    // When - Send initialized notification
+    InitializedParams initializedParams = new InitializedParams();
+    server.initialized(initializedParams);
 
     // When - Shutdown
     CompletableFuture<Object> shutdownFuture = server.shutdown();

--- a/lsp-core/src/test/java/com/groovylsp/presentation/server/GroovyLanguageServerTest.java
+++ b/lsp-core/src/test/java/com/groovylsp/presentation/server/GroovyLanguageServerTest.java
@@ -9,6 +9,7 @@ import com.groovylsp.testing.FastTest;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,16 @@ class GroovyLanguageServerTest {
     // Then
     assertNotNull(result);
     assertNotNull(result.getCapabilities());
+  }
+
+  @Test
+  @FastTest
+  void testInitialized() {
+    // Given
+    InitializedParams params = new InitializedParams();
+
+    // When/Then - Should not throw exception
+    server.initialized(params);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- initialize/initializedメッセージのハンドリングを実装
- 空のサーバー能力（capabilities）を返す実装
- 初期化シーケンスのテストを追加

## Test plan
- [x] 単体テスト（GroovyLanguageServerTest）でinitializedメソッドをテスト
- [x] 統合テスト（LanguageServerIntegrationTest）で完全な初期化シーケンスをテスト  
- [x] JSON-RPC通信テスト（JsonRpcCommunicationTest）でクライアント-サーバー間の接続を確認
- [x] ./gradlew test で全テストが成功することを確認
- [x] ./gradlew check で静的解析が通ることを確認

## Related
Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)