### PR TITLE
[Phase 1] M1.2: 最初の診断機能

### DIFF
--- a/lsp-core/src/main/java/com/groovylsp/application/package-info.java
+++ b/lsp-core/src/main/java/com/groovylsp/application/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.groovylsp.application;
+
+import org.jspecify.annotations.NullMarked;

--- a/lsp-core/src/main/java/com/groovylsp/application/usecase/DiagnosticUseCase.java
+++ b/lsp-core/src/main/java/com/groovylsp/application/usecase/DiagnosticUseCase.java
@@ -1,0 +1,45 @@
+package com.groovylsp.application.usecase;
+
+import com.groovylsp.domain.model.DiagnosticItem;
+import com.groovylsp.domain.model.DiagnosticResult;
+import com.groovylsp.domain.model.TextDocument;
+import io.vavr.control.Either;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** 診断機能のユースケース。 */
+@Singleton
+public class DiagnosticUseCase {
+
+  private static final Logger logger = LoggerFactory.getLogger(DiagnosticUseCase.class);
+
+  @Inject
+  public DiagnosticUseCase() {}
+
+  /**
+   * テキストドキュメントを診断する。
+   *
+   * @param document 診断対象のドキュメント
+   * @return 診断結果またはエラー
+   */
+  public Either<String, DiagnosticResult> diagnose(TextDocument document) {
+    logger.info("Starting diagnosis for document: {}", document.uri());
+
+    // Phase 1 M1.2: 固定メッセージを表示
+    var diagnosticItem =
+        new DiagnosticItem(
+            new DiagnosticItem.DocumentPosition(0, 0),
+            new DiagnosticItem.DocumentPosition(0, 0),
+            DiagnosticItem.DiagnosticSeverity.INFORMATION,
+            "Hello from Groovy LSP",
+            "groovy-lsp");
+
+    var result = new DiagnosticResult(document.uri(), List.of(diagnosticItem));
+
+    logger.info("Diagnosis completed with {} items", result.diagnostics().size());
+    return Either.right(result);
+  }
+}

--- a/lsp-core/src/main/java/com/groovylsp/application/usecase/package-info.java
+++ b/lsp-core/src/main/java/com/groovylsp/application/usecase/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.groovylsp.application.usecase;
+
+import org.jspecify.annotations.NullMarked;

--- a/lsp-core/src/main/java/com/groovylsp/domain/model/DiagnosticItem.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/model/DiagnosticItem.java
@@ -1,0 +1,50 @@
+package com.groovylsp.domain.model;
+
+import java.util.Objects;
+
+/** 診断結果の個別アイテムを表すドメインモデル。 */
+public record DiagnosticItem(
+    DocumentPosition startPosition,
+    DocumentPosition endPosition,
+    DiagnosticSeverity severity,
+    String message,
+    String source) {
+
+  public DiagnosticItem {
+    Objects.requireNonNull(startPosition, "startPosition must not be null");
+    Objects.requireNonNull(endPosition, "endPosition must not be null");
+    Objects.requireNonNull(severity, "severity must not be null");
+    Objects.requireNonNull(message, "message must not be null");
+    Objects.requireNonNull(source, "source must not be null");
+  }
+
+  /** 診断の重要度レベル。 */
+  public enum DiagnosticSeverity {
+    ERROR(1),
+    WARNING(2),
+    INFORMATION(3),
+    HINT(4);
+
+    private final int value;
+
+    DiagnosticSeverity(int value) {
+      this.value = value;
+    }
+
+    public int getValue() {
+      return value;
+    }
+  }
+
+  /** ドキュメント内の位置を表す。 */
+  public record DocumentPosition(int line, int character) {
+    public DocumentPosition {
+      if (line < 0) {
+        throw new IllegalArgumentException("line must be non-negative");
+      }
+      if (character < 0) {
+        throw new IllegalArgumentException("character must be non-negative");
+      }
+    }
+  }
+}

--- a/lsp-core/src/main/java/com/groovylsp/domain/model/DiagnosticResult.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/model/DiagnosticResult.java
@@ -1,0 +1,26 @@
+package com.groovylsp.domain.model;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Objects;
+
+/** ドキュメントの診断結果を表すドメインモデル。 */
+public record DiagnosticResult(URI documentUri, List<DiagnosticItem> diagnostics) {
+
+  public DiagnosticResult {
+    Objects.requireNonNull(documentUri, "documentUri must not be null");
+    Objects.requireNonNull(diagnostics, "diagnostics must not be null");
+    // イミュータブルにする
+    diagnostics = List.copyOf(diagnostics);
+  }
+
+  /** 空の診断結果を作成する。 */
+  public static DiagnosticResult empty(URI documentUri) {
+    return new DiagnosticResult(documentUri, List.of());
+  }
+
+  /** 診断アイテムが存在するかどうかを判定する。 */
+  public boolean hasDiagnostics() {
+    return !diagnostics.isEmpty();
+  }
+}

--- a/lsp-core/src/main/java/com/groovylsp/domain/model/package-info.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/model/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.groovylsp.domain.model;
+
+import org.jspecify.annotations.NullMarked;

--- a/lsp-core/src/main/java/com/groovylsp/domain/package-info.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package com.groovylsp.domain;
+
+import org.jspecify.annotations.NullMarked;

--- a/lsp-core/src/main/java/com/groovylsp/infrastructure/di/ServerModule.java
+++ b/lsp-core/src/main/java/com/groovylsp/infrastructure/di/ServerModule.java
@@ -1,5 +1,6 @@
 package com.groovylsp.infrastructure.di;
 
+import com.groovylsp.application.usecase.DiagnosticUseCase;
 import com.groovylsp.application.usecase.TextDocumentSyncUseCase;
 import com.groovylsp.domain.repository.TextDocumentRepository;
 import com.groovylsp.infrastructure.repository.InMemoryTextDocumentRepository;
@@ -21,8 +22,9 @@ public class ServerModule {
 
   @Provides
   @Singleton
-  public GroovyTextDocumentService provideTextDocumentService(TextDocumentSyncUseCase syncUseCase) {
-    return new GroovyTextDocumentService(syncUseCase);
+  public GroovyTextDocumentService provideTextDocumentService(
+      TextDocumentSyncUseCase syncUseCase, DiagnosticUseCase diagnosticUseCase) {
+    return new GroovyTextDocumentService(syncUseCase, diagnosticUseCase);
   }
 
   @Provides

--- a/lsp-core/src/main/java/com/groovylsp/presentation/server/GroovyTextDocumentService.java
+++ b/lsp-core/src/main/java/com/groovylsp/presentation/server/GroovyTextDocumentService.java
@@ -1,12 +1,22 @@
 package com.groovylsp.presentation.server;
 
+import com.groovylsp.application.usecase.DiagnosticUseCase;
 import com.groovylsp.application.usecase.TextDocumentSyncUseCase;
+import com.groovylsp.domain.model.DiagnosticItem;
+import com.groovylsp.domain.model.DiagnosticResult;
+import java.util.ArrayList;
+import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.TextDocumentService;
@@ -22,17 +32,24 @@ public class GroovyTextDocumentService implements TextDocumentService, LanguageC
 
   private @Nullable LanguageClient client;
   private final TextDocumentSyncUseCase syncUseCase;
+  private final DiagnosticUseCase diagnosticUseCase;
 
   @Inject
-  public GroovyTextDocumentService(TextDocumentSyncUseCase syncUseCase) {
+  public GroovyTextDocumentService(
+      TextDocumentSyncUseCase syncUseCase, DiagnosticUseCase diagnosticUseCase) {
     this.syncUseCase = syncUseCase;
+    this.diagnosticUseCase = diagnosticUseCase;
   }
 
   @Override
   public void didOpen(DidOpenTextDocumentParams params) {
     syncUseCase
         .openDocument(params)
-        .peek(document -> logger.info("Successfully opened document: {}", document.uri()))
+        .peek(
+            document -> {
+              logger.info("Successfully opened document: {}", document.uri());
+              runDiagnostics(document);
+            })
         .peekLeft(error -> logger.error("Failed to open document: {}", error));
   }
 
@@ -41,11 +58,13 @@ public class GroovyTextDocumentService implements TextDocumentService, LanguageC
     syncUseCase
         .changeDocument(params)
         .peek(
-            document ->
-                logger.info(
-                    "Successfully changed document: {} (version: {})",
-                    document.uri(),
-                    document.version()))
+            document -> {
+              logger.info(
+                  "Successfully changed document: {} (version: {})",
+                  document.uri(),
+                  document.version());
+              runDiagnostics(document);
+            })
         .peekLeft(error -> logger.error("Failed to change document: {}", error));
   }
 
@@ -69,5 +88,66 @@ public class GroovyTextDocumentService implements TextDocumentService, LanguageC
 
   protected @Nullable LanguageClient getClient() {
     return client;
+  }
+
+  /**
+   * ドキュメントの診断を実行し、結果をクライアントに送信する。
+   *
+   * @param document 診断対象のドキュメント
+   */
+  private void runDiagnostics(com.groovylsp.domain.model.TextDocument document) {
+    var currentClient = client;
+    if (currentClient == null) {
+      logger.warn("Language client not connected, skipping diagnostics");
+      return;
+    }
+
+    diagnosticUseCase
+        .diagnose(document)
+        .peek(
+            result -> {
+              var diagnostics = convertToLspDiagnostics(result);
+              var params = new PublishDiagnosticsParams(document.uri().toString(), diagnostics);
+              currentClient.publishDiagnostics(params);
+              logger.info("Published {} diagnostics for {}", diagnostics.size(), document.uri());
+            })
+        .peekLeft(error -> logger.error("Failed to run diagnostics: {}", error));
+  }
+
+  /**
+   * ドメインモデルの診断結果をLSPのDiagnosticに変換する。
+   *
+   * @param result 診断結果
+   * @return LSPのDiagnosticリスト
+   */
+  private List<Diagnostic> convertToLspDiagnostics(DiagnosticResult result) {
+    var diagnostics = new ArrayList<Diagnostic>();
+    for (var item : result.diagnostics()) {
+      var diagnostic = new Diagnostic();
+      diagnostic.setRange(
+          new Range(
+              new Position(item.startPosition().line(), item.startPosition().character()),
+              new Position(item.endPosition().line(), item.endPosition().character())));
+      diagnostic.setSeverity(convertSeverity(item.severity()));
+      diagnostic.setMessage(item.message());
+      diagnostic.setSource(item.source());
+      diagnostics.add(diagnostic);
+    }
+    return diagnostics;
+  }
+
+  /**
+   * 診断の重要度をLSPのDiagnosticSeverityに変換する。
+   *
+   * @param severity ドメインモデルの重要度
+   * @return LSPのDiagnosticSeverity
+   */
+  private DiagnosticSeverity convertSeverity(DiagnosticItem.DiagnosticSeverity severity) {
+    return switch (severity) {
+      case ERROR -> DiagnosticSeverity.Error;
+      case WARNING -> DiagnosticSeverity.Warning;
+      case INFORMATION -> DiagnosticSeverity.Information;
+      case HINT -> DiagnosticSeverity.Hint;
+    };
   }
 }

--- a/lsp-core/src/test/java/com/groovylsp/presentation/server/GroovyTextDocumentServiceTest.java
+++ b/lsp-core/src/test/java/com/groovylsp/presentation/server/GroovyTextDocumentServiceTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.groovylsp.application.usecase.DiagnosticUseCase;
 import com.groovylsp.application.usecase.TextDocumentSyncUseCase;
 import com.groovylsp.domain.model.TextDocument;
 import com.groovylsp.testing.FastTest;
@@ -27,13 +28,15 @@ class GroovyTextDocumentServiceTest {
 
   private GroovyTextDocumentService service;
   private TextDocumentSyncUseCase syncUseCase;
+  private DiagnosticUseCase diagnosticUseCase;
   private LanguageClient client;
 
   @BeforeEach
   void setUp() {
     syncUseCase = mock(TextDocumentSyncUseCase.class);
+    diagnosticUseCase = mock(DiagnosticUseCase.class);
     client = mock(LanguageClient.class);
-    service = new GroovyTextDocumentService(syncUseCase);
+    service = new GroovyTextDocumentService(syncUseCase, diagnosticUseCase);
     service.connect(client);
   }
 
@@ -45,6 +48,9 @@ class GroovyTextDocumentServiceTest {
     var document = new TextDocument(URI.create(uri), "groovy", 1, "class Test {}");
 
     when(syncUseCase.openDocument(params)).thenReturn(Either.right(document));
+    when(diagnosticUseCase.diagnose(document))
+        .thenReturn(
+            Either.right(com.groovylsp.domain.model.DiagnosticResult.empty(URI.create(uri))));
 
     service.didOpen(params);
 
@@ -75,6 +81,9 @@ class GroovyTextDocumentServiceTest {
     var document = new TextDocument(URI.create(uri), "groovy", 2, "class Test { void test() {} }");
 
     when(syncUseCase.changeDocument(params)).thenReturn(Either.right(document));
+    when(diagnosticUseCase.diagnose(document))
+        .thenReturn(
+            Either.right(com.groovylsp.domain.model.DiagnosticResult.empty(URI.create(uri))));
 
     service.didChange(params);
 


### PR DESCRIPTION
## 概要
固定メッセージ「Hello from Groovy LSP」を全ファイルに表示する診断機能を実装しました。

## 変更内容
- DiagnosticItemとDiagnosticResultのドメインモデルを追加
- DiagnosticUseCaseを実装（固定メッセージを返す）
- GroovyTextDocumentServiceに診断機能を統合（didOpen/didChange時に実行）
- Daggerモジュールを更新してDiagnosticUseCaseを注入
- JSpecify準拠のための@NullMarkedパッケージ情報を追加
- テストを更新して診断実行に対応

## テスト結果
- すべてのユニットテストがパス（41テスト）
- カバレッジ要件を満たしています

## チェックリスト
- [x] 固定メッセージ「Hello from Groovy LSP」を全ファイルに表示
- [x] PublishDiagnosticsの実装
- [ ] VSCodeで診断メッセージが見えることを確認（統合テストで確認予定）

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)