### PR TITLE
feat: ASTの基本構築機能を実装 (#11)

### DIFF
--- a/lsp-core/src/main/java/com/groovylsp/domain/model/AstInfo.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/model/AstInfo.java
@@ -1,0 +1,46 @@
+package com.groovylsp.domain.model;
+
+import java.util.List;
+
+/**
+ * AST解析結果を表すドメインモデル
+ *
+ * <p>GroovyソースコードのAST解析結果をまとめて保持します。 LSPの各機能で共通的に使用されます。
+ */
+public record AstInfo(
+    String uri,
+    List<ClassInfo> classes,
+    List<DiagnosticItem> syntaxErrors,
+    String packageName,
+    List<String> imports) {
+
+  /** クラスが定義されているかどうかを判定 */
+  public boolean hasClasses() {
+    return !classes.isEmpty();
+  }
+
+  /** 構文エラーがあるかどうかを判定 */
+  public boolean hasSyntaxErrors() {
+    return !syntaxErrors.isEmpty();
+  }
+
+  /**
+   * 指定した名前のクラスを検索
+   *
+   * @param className クラス名
+   * @return 見つかったクラス情報、見つからない場合はnull
+   */
+  public ClassInfo findClassByName(String className) {
+    return classes.stream().filter(c -> c.name().equals(className)).findFirst().orElse(null);
+  }
+
+  /** すべてのメソッド情報を取得 */
+  public List<MethodInfo> getAllMethods() {
+    return classes.stream().flatMap(c -> c.methods().stream()).toList();
+  }
+
+  /** すべてのフィールド情報を取得 */
+  public List<FieldInfo> getAllFields() {
+    return classes.stream().flatMap(c -> c.fields().stream()).toList();
+  }
+}

--- a/lsp-core/src/main/java/com/groovylsp/domain/model/ClassInfo.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/model/ClassInfo.java
@@ -1,0 +1,71 @@
+package com.groovylsp.domain.model;
+
+import java.util.List;
+
+/**
+ * クラス情報を表すドメインモデル
+ *
+ * <p>GroovyソースコードのASTから抽出されたクラス定義の情報を保持します。 LSPの各機能（定義ジャンプ、補完、ホバー等）で使用されます。
+ */
+public record ClassInfo(
+    String name,
+    String qualifiedName,
+    ClassType type,
+    Position position,
+    List<MethodInfo> methods,
+    List<FieldInfo> fields,
+    List<String> superTypes,
+    List<String> interfaces,
+    int modifiers) {
+
+  /** クラスの種別 */
+  public enum ClassType {
+    /** 通常のクラス */
+    CLASS,
+    /** インターフェース */
+    INTERFACE,
+    /** 列挙型 */
+    ENUM,
+    /** アノテーション */
+    ANNOTATION,
+    /** トレイト */
+    TRAIT,
+    /** Groovyスクリプト */
+    SCRIPT
+  }
+
+  /** パブリッククラスかどうかを判定 */
+  public boolean isPublic() {
+    return java.lang.reflect.Modifier.isPublic(modifiers);
+  }
+
+  /** 抽象クラスかどうかを判定 */
+  public boolean isAbstract() {
+    return java.lang.reflect.Modifier.isAbstract(modifiers);
+  }
+
+  /** ファイナルクラスかどうかを判定 */
+  public boolean isFinal() {
+    return java.lang.reflect.Modifier.isFinal(modifiers);
+  }
+
+  /**
+   * 位置情報（ソースコード内の位置）
+   *
+   * @param startLine 開始行（1ベース）
+   * @param startColumn 開始列（1ベース）
+   * @param endLine 終了行（1ベース）
+   * @param endColumn 終了列（1ベース）
+   */
+  public record Position(int startLine, int startColumn, int endLine, int endColumn) {
+    /** LSP準拠の位置情報（0ベース）に変換 */
+    public DiagnosticItem.DocumentPosition toStartLspPosition() {
+      return new DiagnosticItem.DocumentPosition(startLine - 1, startColumn - 1);
+    }
+
+    /** LSP準拠の終了位置情報（0ベース）に変換 */
+    public DiagnosticItem.DocumentPosition toEndLspPosition() {
+      return new DiagnosticItem.DocumentPosition(endLine - 1, endColumn - 1);
+    }
+  }
+}

--- a/lsp-core/src/main/java/com/groovylsp/domain/model/FieldInfo.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/model/FieldInfo.java
@@ -1,0 +1,52 @@
+package com.groovylsp.domain.model;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * フィールド情報を表すドメインモデル
+ *
+ * <p>GroovyソースコードのASTから抽出されたフィールド定義の情報を保持します。 LSPの各機能（定義ジャンプ、補完、ホバー等）で使用されます。
+ */
+public record FieldInfo(
+    String name,
+    String type,
+    ClassInfo.Position position,
+    int modifiers,
+    @Nullable String initialValue,
+    @Nullable String documentation) {
+
+  /** パブリックフィールドかどうかを判定 */
+  public boolean isPublic() {
+    return java.lang.reflect.Modifier.isPublic(modifiers);
+  }
+
+  /** プライベートフィールドかどうかを判定 */
+  public boolean isPrivate() {
+    return java.lang.reflect.Modifier.isPrivate(modifiers);
+  }
+
+  /** 保護フィールドかどうかを判定 */
+  public boolean isProtected() {
+    return java.lang.reflect.Modifier.isProtected(modifiers);
+  }
+
+  /** 静的フィールドかどうかを判定 */
+  public boolean isStatic() {
+    return java.lang.reflect.Modifier.isStatic(modifiers);
+  }
+
+  /** ファイナルフィールドかどうかを判定 */
+  public boolean isFinal() {
+    return java.lang.reflect.Modifier.isFinal(modifiers);
+  }
+
+  /** 揮発性フィールドかどうかを判定 */
+  public boolean isVolatile() {
+    return java.lang.reflect.Modifier.isVolatile(modifiers);
+  }
+
+  /** 一時的フィールドかどうかを判定 */
+  public boolean isTransient() {
+    return java.lang.reflect.Modifier.isTransient(modifiers);
+  }
+}

--- a/lsp-core/src/main/java/com/groovylsp/domain/model/MethodInfo.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/model/MethodInfo.java
@@ -1,0 +1,62 @@
+package com.groovylsp.domain.model;
+
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * メソッド情報を表すドメインモデル
+ *
+ * <p>GroovyソースコードのASTから抽出されたメソッド定義の情報を保持します。 LSPの各機能（定義ジャンプ、補完、シグネチャヘルプ等）で使用されます。
+ */
+public record MethodInfo(
+    String name,
+    String returnType,
+    List<ParameterInfo> parameters,
+    ClassInfo.Position position,
+    int modifiers,
+    @Nullable String documentation) {
+
+  /** パブリックメソッドかどうかを判定 */
+  public boolean isPublic() {
+    return java.lang.reflect.Modifier.isPublic(modifiers);
+  }
+
+  /** プライベートメソッドかどうかを判定 */
+  public boolean isPrivate() {
+    return java.lang.reflect.Modifier.isPrivate(modifiers);
+  }
+
+  /** 保護メソッドかどうかを判定 */
+  public boolean isProtected() {
+    return java.lang.reflect.Modifier.isProtected(modifiers);
+  }
+
+  /** 静的メソッドかどうかを判定 */
+  public boolean isStatic() {
+    return java.lang.reflect.Modifier.isStatic(modifiers);
+  }
+
+  /** 抽象メソッドかどうかを判定 */
+  public boolean isAbstract() {
+    return java.lang.reflect.Modifier.isAbstract(modifiers);
+  }
+
+  /** ファイナルメソッドかどうかを判定 */
+  public boolean isFinal() {
+    return java.lang.reflect.Modifier.isFinal(modifiers);
+  }
+
+  /** メソッドのシグネチャを文字列として取得 */
+  public String getSignature() {
+    var params =
+        parameters.stream()
+            .map(p -> p.type() + " " + p.name())
+            .reduce((a, b) -> a + ", " + b)
+            .orElse("");
+    return name + "(" + params + ")";
+  }
+
+  /** メソッドパラメータ情報 */
+  public record ParameterInfo(
+      String name, String type, @Nullable String defaultValue, boolean isVarArgs) {}
+}

--- a/lsp-core/src/main/java/com/groovylsp/domain/service/AstAnalysisService.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/service/AstAnalysisService.java
@@ -1,0 +1,267 @@
+package com.groovylsp.domain.service;
+
+import com.groovylsp.domain.model.AstInfo;
+import com.groovylsp.domain.model.ClassInfo;
+import com.groovylsp.domain.model.DiagnosticItem;
+import com.groovylsp.domain.model.FieldInfo;
+import com.groovylsp.domain.model.MethodInfo;
+import com.groovylsp.infrastructure.parser.GroovyAstParser;
+import io.vavr.control.Either;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.ast.FieldNode;
+import org.codehaus.groovy.ast.MethodNode;
+import org.codehaus.groovy.ast.ModuleNode;
+import org.codehaus.groovy.ast.Parameter;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * AST解析サービス
+ *
+ * <p>GroovyAstParserの結果をドメインモデルに変換します。
+ */
+@NullMarked
+@Singleton
+public class AstAnalysisService {
+
+  private final GroovyAstParser parser;
+
+  @Inject
+  public AstAnalysisService(GroovyAstParser parser) {
+    this.parser = parser;
+  }
+
+  /**
+   * ソースコードを解析してAST情報を取得
+   *
+   * @param uri ドキュメントURI
+   * @param sourceCode ソースコード
+   * @return AST情報またはエラー
+   */
+  public Either<String, AstInfo> analyze(String uri, String sourceCode) {
+    // ファイル名をURIから抽出
+    String fileName = extractFileName(uri);
+
+    return parser
+        .parse(fileName, sourceCode)
+        .map(parseResult -> convertToAstInfo(uri, parseResult))
+        .mapLeft(error -> error.message());
+  }
+
+  /** URIからファイル名を抽出 */
+  private String extractFileName(String uri) {
+    if (uri.contains("/")) {
+      return uri.substring(uri.lastIndexOf("/") + 1);
+    }
+    return uri;
+  }
+
+  /** ParseResultをAstInfoに変換 */
+  private AstInfo convertToAstInfo(String uri, GroovyAstParser.ParseResult parseResult) {
+    ModuleNode moduleNode = parseResult.moduleNode();
+
+    // パッケージ名を取得（エラー時はmoduleNodeがnullの場合がある）
+    String packageName = "";
+    if (moduleNode != null && moduleNode.getPackageName() != null) {
+      packageName = moduleNode.getPackageName();
+      // パッケージ名の末尾のドットを削除
+      if (packageName.endsWith(".")) {
+        packageName = packageName.substring(0, packageName.length() - 1);
+      }
+    }
+
+    // インポート文を取得
+    List<String> imports = new ArrayList<>();
+    if (moduleNode != null && moduleNode.getImports() != null) {
+      imports =
+          moduleNode.getImports().stream()
+              .map(importNode -> importNode.getClassName())
+              .collect(Collectors.toList());
+    }
+
+    // クラス情報を変換
+    List<ClassInfo> classes = new ArrayList<>();
+    for (ClassNode classNode : parseResult.getClasses()) {
+      ClassInfo classInfo = convertClassNode(classNode);
+      if (classInfo != null) {
+        classes.add(classInfo);
+      }
+    }
+
+    // 構文エラーを診断アイテムに変換
+    List<DiagnosticItem> syntaxErrors =
+        parseResult.diagnostics().stream()
+            .filter(diag -> diag.severity() == GroovyAstParser.ParseDiagnostic.Severity.ERROR)
+            .map(this::convertToDiagnosticItem)
+            .collect(Collectors.toList());
+
+    return new AstInfo(uri, classes, syntaxErrors, packageName, imports);
+  }
+
+  /** ClassNodeをClassInfoに変換 */
+  private @Nullable ClassInfo convertClassNode(ClassNode classNode) {
+    if (classNode == null) {
+      return null;
+    }
+
+    // クラスの種別を判定
+    ClassInfo.ClassType type = determineClassType(classNode);
+
+    // 位置情報を取得
+    var position =
+        new ClassInfo.Position(
+            classNode.getLineNumber(),
+            classNode.getColumnNumber(),
+            classNode.getLastLineNumber(),
+            classNode.getLastColumnNumber());
+
+    // メソッド情報を変換
+    List<MethodInfo> methods = new ArrayList<>();
+    for (MethodNode methodNode : classNode.getMethods()) {
+      MethodInfo methodInfo = convertMethodNode(methodNode);
+      if (methodInfo != null) {
+        methods.add(methodInfo);
+      }
+    }
+
+    // フィールド情報を変換
+    List<FieldInfo> fields = new ArrayList<>();
+    for (FieldNode fieldNode : classNode.getFields()) {
+      FieldInfo fieldInfo = convertFieldNode(fieldNode);
+      if (fieldInfo != null) {
+        fields.add(fieldInfo);
+      }
+    }
+
+    // スーパータイプを取得
+    List<String> superTypes = new ArrayList<>();
+    if (classNode.getSuperClass() != null
+        && !classNode.getSuperClass().getName().equals("java.lang.Object")) {
+      superTypes.add(classNode.getSuperClass().getName());
+    }
+
+    // インターフェースを取得
+    List<String> interfaces =
+        Arrays.stream(classNode.getInterfaces())
+            .map(ClassNode::getName)
+            .collect(Collectors.toList());
+
+    return new ClassInfo(
+        classNode.getName(),
+        classNode.getName(), // 完全修飾名は後で実装
+        type,
+        position,
+        methods,
+        fields,
+        superTypes,
+        interfaces,
+        classNode.getModifiers());
+  }
+
+  /** クラスの種別を判定 */
+  private ClassInfo.ClassType determineClassType(ClassNode classNode) {
+    if (classNode.isInterface()) {
+      return ClassInfo.ClassType.INTERFACE;
+    } else if (classNode.isEnum()) {
+      return ClassInfo.ClassType.ENUM;
+    } else if (classNode.isAnnotationDefinition()) {
+      return ClassInfo.ClassType.ANNOTATION;
+    } else if (classNode.getName().endsWith("$Trait$Helper")) {
+      return ClassInfo.ClassType.TRAIT;
+    } else if (classNode.isScript()) {
+      return ClassInfo.ClassType.SCRIPT;
+    } else {
+      return ClassInfo.ClassType.CLASS;
+    }
+  }
+
+  /** MethodNodeをMethodInfoに変換 */
+  private @Nullable MethodInfo convertMethodNode(MethodNode methodNode) {
+    if (methodNode == null) {
+      return null;
+    }
+
+    // 位置情報を取得
+    var position =
+        new ClassInfo.Position(
+            methodNode.getLineNumber(),
+            methodNode.getColumnNumber(),
+            methodNode.getLastLineNumber(),
+            methodNode.getLastColumnNumber());
+
+    // パラメータ情報を変換
+    List<MethodInfo.ParameterInfo> parameters = new ArrayList<>();
+    for (Parameter param : methodNode.getParameters()) {
+      parameters.add(
+          new MethodInfo.ParameterInfo(
+              param.getName(),
+              param.getType().getName(),
+              param.hasInitialExpression() ? "has default" : null, // 実際の値は後で実装
+              param.getType().isArray()));
+    }
+
+    // 戻り値の型を取得
+    String returnType = methodNode.getReturnType().getName();
+
+    return new MethodInfo(
+        methodNode.getName(),
+        returnType,
+        parameters,
+        position,
+        methodNode.getModifiers(),
+        null // ドキュメントは後で実装
+        );
+  }
+
+  /** FieldNodeをFieldInfoに変換 */
+  private @Nullable FieldInfo convertFieldNode(FieldNode fieldNode) {
+    if (fieldNode == null) {
+      return null;
+    }
+
+    // 位置情報を取得
+    var position =
+        new ClassInfo.Position(
+            fieldNode.getLineNumber(),
+            fieldNode.getColumnNumber(),
+            fieldNode.getLastLineNumber(),
+            fieldNode.getLastColumnNumber());
+
+    return new FieldInfo(
+        fieldNode.getName(),
+        fieldNode.getType().getName(),
+        position,
+        fieldNode.getModifiers(),
+        fieldNode.hasInitialExpression() ? "has initial value" : null, // 実際の値は後で実装
+        null // ドキュメントは後で実装
+        );
+  }
+
+  /** ParseDiagnosticをDiagnosticItemに変換 */
+  private DiagnosticItem convertToDiagnosticItem(GroovyAstParser.ParseDiagnostic parseDiag) {
+    return new DiagnosticItem(
+        new DiagnosticItem.DocumentPosition(
+            parseDiag.start().line() - 1, parseDiag.start().character() - 1),
+        new DiagnosticItem.DocumentPosition(
+            parseDiag.end().line() - 1, parseDiag.end().character() - 1),
+        convertSeverity(parseDiag.severity()),
+        parseDiag.message(),
+        "groovy-syntax");
+  }
+
+  /** 診断の重要度を変換 */
+  private DiagnosticItem.DiagnosticSeverity convertSeverity(
+      GroovyAstParser.ParseDiagnostic.Severity severity) {
+    return switch (severity) {
+      case ERROR -> DiagnosticItem.DiagnosticSeverity.ERROR;
+      case WARNING -> DiagnosticItem.DiagnosticSeverity.WARNING;
+      case INFO -> DiagnosticItem.DiagnosticSeverity.INFORMATION;
+    };
+  }
+}

--- a/lsp-core/src/main/java/com/groovylsp/domain/service/AstAnalysisService.java
+++ b/lsp-core/src/main/java/com/groovylsp/domain/service/AstAnalysisService.java
@@ -88,7 +88,7 @@ public class AstAnalysisService {
     // クラス情報を変換
     List<ClassInfo> classes = new ArrayList<>();
     for (ClassNode classNode : parseResult.getClasses()) {
-      ClassInfo classInfo = convertClassNode(classNode);
+      ClassInfo classInfo = convertClassNode(classNode, packageName);
       if (classInfo != null) {
         classes.add(classInfo);
       }
@@ -105,7 +105,7 @@ public class AstAnalysisService {
   }
 
   /** ClassNodeをClassInfoに変換 */
-  private @Nullable ClassInfo convertClassNode(ClassNode classNode) {
+  private @Nullable ClassInfo convertClassNode(ClassNode classNode, String packageName) {
     if (classNode == null) {
       return null;
     }
@@ -152,9 +152,15 @@ public class AstAnalysisService {
             .map(ClassNode::getName)
             .collect(Collectors.toList());
 
+    // クラスの単純名を取得（内部クラスの場合も考慮）
+    String simpleName = classNode.getNameWithoutPackage();
+
+    // 完全修飾名を生成
+    String qualifiedName = packageName.isEmpty() ? simpleName : packageName + "." + simpleName;
+
     return new ClassInfo(
-        classNode.getName(),
-        classNode.getName(), // 完全修飾名は後で実装
+        simpleName,
+        qualifiedName,
         type,
         position,
         methods,

--- a/lsp-core/src/main/java/com/groovylsp/infrastructure/di/ServerModule.java
+++ b/lsp-core/src/main/java/com/groovylsp/infrastructure/di/ServerModule.java
@@ -3,8 +3,10 @@ package com.groovylsp.infrastructure.di;
 import com.groovylsp.application.usecase.DiagnosticUseCase;
 import com.groovylsp.application.usecase.TextDocumentSyncUseCase;
 import com.groovylsp.domain.repository.TextDocumentRepository;
+import com.groovylsp.domain.service.AstAnalysisService;
 import com.groovylsp.domain.service.BracketValidationService;
 import com.groovylsp.domain.service.LineCountService;
+import com.groovylsp.infrastructure.parser.GroovyAstParser;
 import com.groovylsp.infrastructure.repository.InMemoryTextDocumentRepository;
 import com.groovylsp.presentation.server.GroovyTextDocumentService;
 import com.groovylsp.presentation.server.GroovyWorkspaceService;
@@ -32,6 +34,18 @@ public class ServerModule {
   @Singleton
   public BracketValidationService provideBracketValidationService() {
     return new BracketValidationService();
+  }
+
+  @Provides
+  @Singleton
+  public GroovyAstParser provideGroovyAstParser() {
+    return new GroovyAstParser();
+  }
+
+  @Provides
+  @Singleton
+  public AstAnalysisService provideAstAnalysisService(GroovyAstParser parser) {
+    return new AstAnalysisService(parser);
   }
 
   @Provides

--- a/lsp-core/src/main/java/com/groovylsp/infrastructure/parser/GroovyAstParser.java
+++ b/lsp-core/src/main/java/com/groovylsp/infrastructure/parser/GroovyAstParser.java
@@ -134,9 +134,12 @@ public class GroovyAstParser implements AutoCloseable {
   }
 
   /** 解析結果 */
-  public record ParseResult(ModuleNode moduleNode, List<ParseDiagnostic> diagnostics) {
+  public record ParseResult(@Nullable ModuleNode moduleNode, List<ParseDiagnostic> diagnostics) {
     /** すべてのクラスノードを取得 */
     public List<ClassNode> getClasses() {
+      if (moduleNode == null) {
+        return List.of();
+      }
       var classes = moduleNode.getClasses();
       return classes != null ? new ArrayList<>(classes) : List.of();
     }

--- a/lsp-core/src/test/java/com/groovylsp/domain/service/AstAnalysisServiceTest.java
+++ b/lsp-core/src/test/java/com/groovylsp/domain/service/AstAnalysisServiceTest.java
@@ -1,0 +1,396 @@
+package com.groovylsp.domain.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.groovylsp.domain.model.ClassInfo;
+import com.groovylsp.domain.model.DiagnosticItem;
+import com.groovylsp.infrastructure.parser.GroovyAstParser;
+import com.groovylsp.testing.FastTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** AstAnalysisServiceのテスト */
+@FastTest
+class AstAnalysisServiceTest {
+
+  private AstAnalysisService service;
+  private GroovyAstParser parser;
+
+  @BeforeEach
+  void setUp() {
+    parser = new GroovyAstParser();
+    service = new AstAnalysisService(parser);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (parser != null) {
+      parser.close();
+    }
+  }
+
+  @Nested
+  @DisplayName("クラス定義の認識")
+  class ClassRecognition {
+
+    @Test
+    @DisplayName("シンプルなクラス定義を認識できる")
+    void recognizeSimpleClass() {
+      // given
+      String sourceCode =
+          """
+                class HelloWorld {
+                    String message = "Hello, World!"
+
+                    void sayHello() {
+                        println message
+                    }
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/HelloWorld.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.classes()).hasSize(1);
+      var classInfo = astInfo.classes().get(0);
+      assertThat(classInfo.name()).isEqualTo("HelloWorld");
+      assertThat(classInfo.type()).isEqualTo(ClassInfo.ClassType.CLASS);
+      assertThat(classInfo.fields()).hasSize(1);
+      assertThat(classInfo.fields().get(0).name()).isEqualTo("message");
+    }
+
+    @Test
+    @DisplayName("インターフェース定義を認識できる")
+    void recognizeInterface() {
+      // given
+      String sourceCode =
+          """
+                interface Calculator {
+                    int add(int a, int b)
+                    int subtract(int a, int b)
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/Calculator.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.classes()).hasSize(1);
+      var classInfo = astInfo.classes().get(0);
+      assertThat(classInfo.name()).isEqualTo("Calculator");
+      assertThat(classInfo.type()).isEqualTo(ClassInfo.ClassType.INTERFACE);
+      assertThat(classInfo.methods()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("複数のクラス定義を認識できる")
+    void recognizeMultipleClasses() {
+      // given
+      String sourceCode =
+          """
+                class First {
+                    void method1() {}
+                }
+
+                class Second {
+                    void method2() {}
+                }
+
+                interface Third {
+                    void method3()
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/Multiple.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.classes()).hasSize(3);
+      assertThat(astInfo.classes().stream().map(ClassInfo::name))
+          .containsExactlyInAnyOrder("First", "Second", "Third");
+    }
+  }
+
+  @Nested
+  @DisplayName("メソッド定義の認識")
+  class MethodRecognition {
+
+    @Test
+    @DisplayName("メソッド定義を正しく認識できる")
+    void recognizeMethods() {
+      // given
+      String sourceCode =
+          """
+                class MethodTest {
+                    void noArgs() {
+                        println "No arguments"
+                    }
+
+                    String withArgs(String name, int age) {
+                        return "Name: $name, Age: $age"
+                    }
+
+                    private static int staticMethod(int x) {
+                        return x * 2
+                    }
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/MethodTest.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.classes()).hasSize(1);
+      var methods = astInfo.classes().get(0).methods();
+
+      // Groovyは自動的にコンストラクタやゲッター/セッターを生成することがある
+      var userMethods =
+          methods.stream()
+              .filter(
+                  m ->
+                      m.name().equals("noArgs")
+                          || m.name().equals("withArgs")
+                          || m.name().equals("staticMethod"))
+              .toList();
+
+      assertThat(userMethods).hasSize(3);
+
+      // noArgsメソッドの確認
+      var noArgs = userMethods.stream().filter(m -> m.name().equals("noArgs")).findFirst();
+      assertThat(noArgs).isPresent();
+      assertThat(noArgs.get().parameters()).isEmpty();
+      assertThat(noArgs.get().returnType()).isEqualTo("void");
+
+      // withArgsメソッドの確認
+      var withArgs = userMethods.stream().filter(m -> m.name().equals("withArgs")).findFirst();
+      assertThat(withArgs).isPresent();
+      assertThat(withArgs.get().parameters()).hasSize(2);
+      assertThat(withArgs.get().parameters().get(0).name()).isEqualTo("name");
+      assertThat(withArgs.get().parameters().get(0).type()).isEqualTo("String");
+      assertThat(withArgs.get().parameters().get(1).name()).isEqualTo("age");
+      assertThat(withArgs.get().parameters().get(1).type()).isEqualTo("int");
+      assertThat(withArgs.get().returnType()).isEqualTo("String");
+
+      // staticMethodの確認
+      var staticMethod =
+          userMethods.stream().filter(m -> m.name().equals("staticMethod")).findFirst();
+      assertThat(staticMethod).isPresent();
+      assertThat(staticMethod.get().isStatic()).isTrue();
+      assertThat(staticMethod.get().isPrivate()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Spockテストメソッドを認識できる")
+    void recognizeSpockMethods() {
+      // given
+      String sourceCode =
+          """
+                import spock.lang.Specification
+
+                class CalculatorSpec extends Specification {
+                    def "addition should work correctly"() {
+                        given:
+                        def calculator = new Calculator()
+
+                        when:
+                        def result = calculator.add(2, 3)
+
+                        then:
+                        result == 5
+                    }
+
+                    def "subtraction should work"() {
+                        expect:
+                        5 - 3 == 2
+                    }
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/CalculatorSpec.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.classes()).hasSize(1);
+      var methods = astInfo.classes().get(0).methods();
+
+      // Spockのテストメソッドを確認
+      var testMethods = methods.stream().filter(m -> m.name().contains("should")).toList();
+
+      assertThat(testMethods).hasSize(2);
+      assertThat(testMethods.stream().map(m -> m.name()))
+          .containsExactlyInAnyOrder("addition should work correctly", "subtraction should work");
+    }
+  }
+
+  @Nested
+  @DisplayName("構文エラーの検出")
+  class SyntaxErrorDetection {
+
+    @Test
+    @DisplayName("構文エラーを検出できる")
+    void detectSyntaxErrors() {
+      // given
+      String sourceCode =
+          """
+                class BrokenClass {
+                    void method1() {
+                        println "This is valid"
+                    }
+
+                    void method2() {
+                        // 構文エラー: 閉じ括弧がない
+                        println "Missing closing brace"
+
+                    void method3() {
+                        println "This method comes after error"
+                    }
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/BrokenClass.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.hasSyntaxErrors()).isTrue();
+      assertThat(astInfo.syntaxErrors()).isNotEmpty();
+
+      var syntaxError = astInfo.syntaxErrors().get(0);
+      assertThat(syntaxError.severity()).isEqualTo(DiagnosticItem.DiagnosticSeverity.ERROR);
+      assertThat(syntaxError.source()).isEqualTo("groovy-syntax");
+    }
+
+    @Test
+    @DisplayName("不正なインポート文を検出できる")
+    void detectInvalidImport() {
+      // given
+      String sourceCode =
+          """
+                import invalid.package.
+
+                class TestClass {
+                    void test() {
+                        println "test"
+                    }
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/TestClass.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.hasSyntaxErrors()).isTrue();
+      assertThat(astInfo.syntaxErrors()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("エラーがない場合は空のリストを返す")
+    void noErrorsForValidCode() {
+      // given
+      String sourceCode =
+          """
+                class ValidClass {
+                    String name
+                    int age
+
+                    void display() {
+                        println "Name: $name, Age: $age"
+                    }
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/ValidClass.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.hasSyntaxErrors()).isFalse();
+      assertThat(astInfo.syntaxErrors()).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("パッケージとインポートの認識")
+  class PackageAndImportRecognition {
+
+    @Test
+    @DisplayName("パッケージ宣言を認識できる")
+    void recognizePackage() {
+      // given
+      String sourceCode =
+          """
+                package com.example.test
+
+                class TestClass {
+                    void test() {}
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/TestClass.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.packageName()).isEqualTo("com.example.test");
+    }
+
+    @Test
+    @DisplayName("インポート文を認識できる")
+    void recognizeImports() {
+      // given
+      String sourceCode =
+          """
+                package com.example
+
+                import java.util.List
+                import java.util.Map
+                import groovy.transform.CompileStatic
+
+                @CompileStatic
+                class TestClass {
+                    List<String> names
+                    Map<String, Integer> scores
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/TestClass.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.imports())
+          .containsExactlyInAnyOrder(
+              "java.util.List", "java.util.Map", "groovy.transform.CompileStatic");
+    }
+  }
+}

--- a/lsp-core/src/test/java/com/groovylsp/domain/service/AstAnalysisServiceTest.java
+++ b/lsp-core/src/test/java/com/groovylsp/domain/service/AstAnalysisServiceTest.java
@@ -196,6 +196,34 @@ class AstAnalysisServiceTest {
     }
 
     @Test
+    @DisplayName("パッケージ付きクラスの完全修飾名が正しく生成される")
+    void generateQualifiedNameWithPackage() {
+      // given
+      String sourceCode =
+          """
+                package com.example.test
+
+                class TestClass {
+                    String name
+                }
+                """;
+
+      // when
+      var result = service.analyze("file:///test/TestClass.groovy", sourceCode);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      var astInfo = result.get();
+
+      assertThat(astInfo.packageName()).isEqualTo("com.example.test");
+      assertThat(astInfo.classes()).hasSize(1);
+
+      var classInfo = astInfo.classes().get(0);
+      assertThat(classInfo.name()).isEqualTo("TestClass");
+      assertThat(classInfo.qualifiedName()).isEqualTo("com.example.test.TestClass");
+    }
+
+    @Test
     @DisplayName("Spockテストメソッドを認識できる")
     void recognizeSpockMethods() {
       // given

--- a/lsp-core/src/test/java/com/groovylsp/integration/BracketValidationIntegrationTest.java
+++ b/lsp-core/src/test/java/com/groovylsp/integration/BracketValidationIntegrationTest.java
@@ -5,8 +5,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.groovylsp.application.usecase.DiagnosticUseCase;
 import com.groovylsp.domain.model.DiagnosticItem;
 import com.groovylsp.domain.model.TextDocument;
+import com.groovylsp.domain.service.AstAnalysisService;
 import com.groovylsp.domain.service.BracketValidationService;
 import com.groovylsp.domain.service.LineCountService;
+import com.groovylsp.infrastructure.parser.GroovyAstParser;
 import com.groovylsp.testing.IntegrationTest;
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,7 +24,10 @@ class BracketValidationIntegrationTest {
   void setUp() {
     var lineCountService = new LineCountService();
     var bracketValidationService = new BracketValidationService();
-    diagnosticUseCase = new DiagnosticUseCase(lineCountService, bracketValidationService);
+    var parser = new GroovyAstParser();
+    var astAnalysisService = new AstAnalysisService(parser);
+    diagnosticUseCase =
+        new DiagnosticUseCase(lineCountService, bracketValidationService, astAnalysisService);
   }
 
   @Test

--- a/lsp-core/src/test/java/com/groovylsp/integration/DiagnosticIntegrationTest.java
+++ b/lsp-core/src/test/java/com/groovylsp/integration/DiagnosticIntegrationTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.groovylsp.application.usecase.DiagnosticUseCase;
 import com.groovylsp.domain.model.TextDocument;
+import com.groovylsp.domain.service.AstAnalysisService;
 import com.groovylsp.domain.service.BracketValidationService;
 import com.groovylsp.domain.service.LineCountService;
+import com.groovylsp.infrastructure.parser.GroovyAstParser;
 import com.groovylsp.testing.IntegrationTest;
 import java.net.URI;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +26,10 @@ class DiagnosticIntegrationTest {
   void setUp() {
     lineCountService = new LineCountService();
     bracketValidationService = new BracketValidationService();
-    diagnosticUseCase = new DiagnosticUseCase(lineCountService, bracketValidationService);
+    var parser = new GroovyAstParser();
+    var astAnalysisService = new AstAnalysisService(parser);
+    diagnosticUseCase =
+        new DiagnosticUseCase(lineCountService, bracketValidationService, astAnalysisService);
   }
 
   @Test

--- a/vscode-extension/biome.json
+++ b/vscode-extension/biome.json
@@ -21,7 +21,10 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "all": true
+      "all": true,
+      "correctness": {
+        "noNodejsModules": "off"
+      }
     }
   },
   "javascript": {

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -17,13 +17,14 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^24.0.1",
         "@types/vscode": "^1.101.0",
-        "@vscode/test-electron": "^2.4.1",
+        "@vscode/test-electron": "^2.5.2",
         "c8": "^10.1.3",
         "esbuild": "^0.25.5",
         "glob": "^11.0.0",
         "mocha": "^10.8.2",
         "ts-node": "^10.9.2",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "vscode": "^1.1.37"
       },
       "engines": {
         "vscode": "^1.75.0"
@@ -731,6 +732,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -975,6 +986,13 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/c8": {
       "version": "10.1.3",
@@ -1309,6 +1327,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1399,6 +1431,23 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -1601,6 +1650,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.x"
       }
     },
     "node_modules/has-flag": {
@@ -1989,6 +2048,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -1997,6 +2063,20 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha512-SknJC52obPfGQPnjIkXbmA6+5H15E+fR+E4iR2oQ3zzCLbd7/ONua69R/Gw7AgkTLsRG+r5fzksYwWe1AgTyWA==",
+      "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "0.0.8"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/mocha": {
@@ -2273,6 +2353,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2456,6 +2546,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/stdin-discarder": {
@@ -2834,6 +2945,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/vscode": {
+      "version": "1.1.37",
+      "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.37.tgz",
+      "integrity": "sha512-vJNj6IlN7IJPdMavlQa1KoFB3Ihn06q1AiN3ZFI/HfzPNzbKZWPPuiU+XkpNOfGU5k15m4r80nxNPlM7wcc0wg==",
+      "deprecated": "This package is deprecated in favor of @types/vscode and vscode-test. For more information please read: https://code.visualstudio.com/updates/v1_36#_splitting-vscode-package-into-typesvscode-and-vscodetest",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.1.2",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "mocha": "^5.2.0",
+        "semver": "^5.4.1",
+        "source-map-support": "^0.5.0",
+        "vscode-test": "^0.4.1"
+      },
+      "bin": {
+        "vscode-install": "bin/install"
+      },
+      "engines": {
+        "node": ">=8.9.3"
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -2884,6 +3018,306 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
       "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
       "license": "MIT"
+    },
+    "node_modules/vscode-test": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-0.4.3.tgz",
+      "integrity": "sha512-EkMGqBSefZH2MgW65nY05rdRSko15uvzq4VAPM5jVmwYuFQKE7eikKXNJDRxL+OITXHB6pI+a3XqqD32Y3KC5w==",
+      "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^2.1.0",
+        "https-proxy-agent": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.9.3"
+      }
+    },
+    "node_modules/vscode-test/node_modules/agent-base": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es6-promisify": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/vscode-test/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/vscode-test/node_modules/http-proxy-agent": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "4",
+        "debug": "3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/vscode-test/node_modules/https-proxy-agent": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+      "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^4.3.0",
+        "debug": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
+    "node_modules/vscode-test/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/vscode/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/vscode/node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/vscode/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/vscode/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/vscode/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode/node_modules/he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha512-z/GDPjlRMNOa2XJiB4em8wJpuuBfrFOlYKTZxtpkdr1uPdibHI8rYA3MY0KDObpVyaes0e/aunid/t88ZI2EKA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/vscode/node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vscode/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vscode/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/vscode/node_modules/mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/vscode/node_modules/mocha/node_modules/debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/vscode/node_modules/mocha/node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/vscode/node_modules/mocha/node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/vscode/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/vscode/node_modules/supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -64,13 +64,14 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.1",
     "@types/vscode": "^1.101.0",
-    "@vscode/test-electron": "^2.4.1",
+    "@vscode/test-electron": "^2.5.2",
     "c8": "^10.1.3",
     "esbuild": "^0.25.5",
     "glob": "^11.0.0",
     "mocha": "^10.8.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vscode": "^1.1.37"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.1"

--- a/vscode-extension/scripts/generate-test-scenarios.ts
+++ b/vscode-extension/scripts/generate-test-scenarios.ts
@@ -193,7 +193,7 @@ class TestScenarioExtractor {
 }
 
 // メイン処理
-async function main() {
+function main() {
   const extractor = new TestScenarioExtractor();
   const testRoot = join(__dirname, '../src/test');
 

--- a/vscode-extension/src/test/SCENARIOS.md
+++ b/vscode-extension/src/test/SCENARIOS.md
@@ -2,9 +2,9 @@
 
 ## 概要
 
-- **総テスト数**: 31
+- **総テスト数**: 39
 - **単体テスト**: 8
-- **統合テスト**: 23
+- **統合テスト**: 31
 - **E2Eテスト**: 0
 
 ## 単体テスト
@@ -26,6 +26,30 @@
 - String test
 
 ## 統合テスト
+
+### 構文エラーの検出
+*ファイル: src/test/integration/ast-analysis.spec.ts*
+
+- 閉じ括弧が不足している場合、構文エラーが検出される
+- 不正なインポート文がある場合、構文エラーが検出される
+- 正しい構文の場合、構文エラーが検出されない
+
+### クラス定義の認識
+*ファイル: src/test/integration/ast-analysis.spec.ts*
+
+- 複数のクラス定義がある場合でも、各クラスが正しく認識される
+
+### メソッド定義の認識
+*ファイル: src/test/integration/ast-analysis.spec.ts*
+
+- Spockテストメソッドの特殊な名前が正しく認識される
+- 様々なメソッド修飾子が正しく認識される
+
+### 複雑な構文の処理
+*ファイル: src/test/integration/ast-analysis.spec.ts*
+
+- クロージャとGStringを含むコードが正しく解析される
+- Groovy特有の構文（プロパティアクセス、安全参照演算子など）が正しく解析される
 
 ### 括弧の対応チェック機能のテスト
 *ファイル: src/test/integration/bracket-matching.spec.ts*

--- a/vscode-extension/src/test/integration/ast-analysis.spec.ts
+++ b/vscode-extension/src/test/integration/ast-analysis.spec.ts
@@ -1,6 +1,9 @@
-import { ok, strictEqual } from 'node:assert/strict';
+import { strictEqual } from 'node:assert/strict';
 import { DiagnosticSeverity, type TextDocument, extensions, languages } from 'vscode';
 import { closeDoc, openDoc } from '../test-utils/lsp.ts';
+
+// テストで使用する待機時間の定数
+const WAIT_TIME_MS = 3000;
 
 describe('AST解析機能のテスト', () => {
   let doc: TextDocument;
@@ -13,7 +16,7 @@ describe('AST解析機能のテスト', () => {
       await extension.activate();
     }
     // LSPサーバーが完全に起動するまで待つ
-    await new Promise((resolve) => setTimeout(resolve, 3000));
+    await new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS));
   });
 
   afterEach(async () => {
@@ -32,18 +35,19 @@ describe('AST解析機能のテスト', () => {
       `;
 
       doc = await openDoc(code, 'groovy');
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS));
 
       const diagnostics = languages.getDiagnostics(doc.uri);
       const syntaxErrors = diagnostics.filter(
         (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
       );
 
-      ok(syntaxErrors.length > 0, '構文エラーが検出されるべきです');
-      ok(
+      strictEqual(syntaxErrors.length > 0, true, '構文エラーが検出されるべきです');
+      strictEqual(
         syntaxErrors.some(
           (e) => e.message.toLowerCase().includes('unexpected') || e.message.toLowerCase().includes('missing'),
         ),
+        true,
         'エラーメッセージに構文エラーの詳細が含まれるべきです',
       );
     });
@@ -60,14 +64,14 @@ describe('AST解析機能のテスト', () => {
       `;
 
       doc = await openDoc(code, 'groovy');
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS));
 
       const diagnostics = languages.getDiagnostics(doc.uri);
       const syntaxErrors = diagnostics.filter(
         (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
       );
 
-      ok(syntaxErrors.length > 0, '不正なインポート文に対してエラーが検出されるべきです');
+      strictEqual(syntaxErrors.length > 0, true, '不正なインポート文に対してエラーが検出されるべきです');
     });
 
     it('正しい構文の場合、構文エラーが検出されない', async () => {
@@ -87,7 +91,7 @@ describe('AST解析機能のテスト', () => {
       `;
 
       doc = await openDoc(code, 'groovy');
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS));
 
       const diagnostics = languages.getDiagnostics(doc.uri);
       const syntaxErrors = diagnostics.filter(
@@ -117,7 +121,7 @@ describe('AST解析機能のテスト', () => {
       `;
 
       doc = await openDoc(code, 'groovy');
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS));
 
       const diagnostics = languages.getDiagnostics(doc.uri);
 
@@ -129,7 +133,7 @@ describe('AST解析機能のテスト', () => {
 
       // 行カウント情報が存在することで、AST解析が成功したことを間接的に確認
       const lineCountDiagnostic = diagnostics.find((d) => d.source === 'groovy-lsp-line-count');
-      ok(lineCountDiagnostic, 'AST解析が成功し、診断情報が生成されるべきです');
+      strictEqual(lineCountDiagnostic !== undefined, true, 'AST解析が成功し、診断情報が生成されるべきです');
     });
   });
 
@@ -158,7 +162,7 @@ describe('AST解析機能のテスト', () => {
       `;
 
       doc = await openDoc(code, 'groovy');
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS));
 
       const diagnostics = languages.getDiagnostics(doc.uri);
 
@@ -192,7 +196,7 @@ describe('AST解析機能のテスト', () => {
       `;
 
       doc = await openDoc(code, 'groovy');
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS));
 
       const diagnostics = languages.getDiagnostics(doc.uri);
 
@@ -233,7 +237,7 @@ describe('AST解析機能のテスト', () => {
       `;
 
       doc = await openDoc(code, 'groovy');
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS));
 
       const diagnostics = languages.getDiagnostics(doc.uri);
 
@@ -277,7 +281,7 @@ describe('AST解析機能のテスト', () => {
       `;
 
       doc = await openDoc(code, 'groovy');
-      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await new Promise((resolve) => setTimeout(resolve, WAIT_TIME_MS));
 
       const diagnostics = languages.getDiagnostics(doc.uri);
 

--- a/vscode-extension/src/test/integration/ast-analysis.spec.ts
+++ b/vscode-extension/src/test/integration/ast-analysis.spec.ts
@@ -1,0 +1,291 @@
+import { ok, strictEqual } from 'node:assert/strict';
+import { DiagnosticSeverity, type TextDocument, extensions, languages } from 'vscode';
+import { closeDoc, openDoc } from '../test-utils/lsp.ts';
+
+describe('AST解析機能のテスト', () => {
+  let doc: TextDocument;
+
+  before(async function () {
+    this.timeout(10000); // before フックのタイムアウトを延長
+    // 拡張機能が正しくアクティベートされているか確認
+    const extension = extensions.getExtension('groovy-lsp.groovy-lsp');
+    if (extension && !extension.isActive) {
+      await extension.activate();
+    }
+    // LSPサーバーが完全に起動するまで待つ
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+  });
+
+  afterEach(async () => {
+    if (doc) {
+      await closeDoc(doc);
+    }
+  });
+
+  describe('構文エラーの検出', () => {
+    it('閉じ括弧が不足している場合、構文エラーが検出される', async () => {
+      const code = `
+        class BrokenClass {
+          void method() {
+            println "Missing closing brace"
+        }
+      `;
+
+      doc = await openDoc(code, 'groovy');
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const diagnostics = languages.getDiagnostics(doc.uri);
+      const syntaxErrors = diagnostics.filter(
+        (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
+      );
+
+      ok(syntaxErrors.length > 0, '構文エラーが検出されるべきです');
+      ok(
+        syntaxErrors.some(
+          (e) => e.message.toLowerCase().includes('unexpected') || e.message.toLowerCase().includes('missing'),
+        ),
+        'エラーメッセージに構文エラーの詳細が含まれるべきです',
+      );
+    });
+
+    it('不正なインポート文がある場合、構文エラーが検出される', async () => {
+      const code = `
+        import invalid.package.
+        
+        class TestClass {
+          void test() {
+            println "test"
+          }
+        }
+      `;
+
+      doc = await openDoc(code, 'groovy');
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const diagnostics = languages.getDiagnostics(doc.uri);
+      const syntaxErrors = diagnostics.filter(
+        (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
+      );
+
+      ok(syntaxErrors.length > 0, '不正なインポート文に対してエラーが検出されるべきです');
+    });
+
+    it('正しい構文の場合、構文エラーが検出されない', async () => {
+      const code = `
+        package com.example
+        
+        import java.util.List
+        
+        class ValidClass {
+          String name
+          int age
+          
+          void display() {
+            println "Name: \$name, Age: \$age"
+          }
+        }
+      `;
+
+      doc = await openDoc(code, 'groovy');
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const diagnostics = languages.getDiagnostics(doc.uri);
+      const syntaxErrors = diagnostics.filter(
+        (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
+      );
+
+      strictEqual(syntaxErrors.length, 0, '正しい構文では構文エラーが検出されないべきです');
+    });
+  });
+
+  describe('クラス定義の認識', () => {
+    it('複数のクラス定義がある場合でも、各クラスが正しく認識される', async () => {
+      const code = `
+        class FirstClass {
+          void method1() {
+            println "First"
+          }
+        }
+        
+        interface SecondInterface {
+          void method2()
+        }
+        
+        enum ThirdEnum {
+          VALUE1, VALUE2
+        }
+      `;
+
+      doc = await openDoc(code, 'groovy');
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const diagnostics = languages.getDiagnostics(doc.uri);
+
+      // 構文エラーがないことを確認
+      const syntaxErrors = diagnostics.filter(
+        (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
+      );
+      strictEqual(syntaxErrors.length, 0, '複数クラス定義で構文エラーが発生しないべきです');
+
+      // 行カウント情報が存在することで、AST解析が成功したことを間接的に確認
+      const lineCountDiagnostic = diagnostics.find((d) => d.source === 'groovy-lsp-line-count');
+      ok(lineCountDiagnostic, 'AST解析が成功し、診断情報が生成されるべきです');
+    });
+  });
+
+  describe('メソッド定義の認識', () => {
+    it('Spockテストメソッドの特殊な名前が正しく認識される', async () => {
+      const code = `
+        import spock.lang.Specification
+        
+        class CalculatorSpec extends Specification {
+          def "addition should work correctly"() {
+            given:
+            def calculator = new Calculator()
+            
+            when:
+            def result = calculator.add(2, 3)
+            
+            then:
+            result == 5
+          }
+          
+          def "subtraction should work"() {
+            expect:
+            5 - 3 == 2
+          }
+        }
+      `;
+
+      doc = await openDoc(code, 'groovy');
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const diagnostics = languages.getDiagnostics(doc.uri);
+
+      // Spockテストの特殊な構文でも構文エラーが発生しないことを確認
+      const syntaxErrors = diagnostics.filter(
+        (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
+      );
+      strictEqual(syntaxErrors.length, 0, 'Spockテストメソッドで構文エラーが発生しないべきです');
+    });
+
+    it('様々なメソッド修飾子が正しく認識される', async () => {
+      const code = `
+        class MethodTest {
+          void publicMethod() {
+            println "Public"
+          }
+          
+          private String privateMethod(String name) {
+            return "Hello, \$name"
+          }
+          
+          protected static int staticMethod(int x) {
+            return x * 2
+          }
+          
+          @Override
+          String toString() {
+            return "MethodTest"
+          }
+        }
+      `;
+
+      doc = await openDoc(code, 'groovy');
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const diagnostics = languages.getDiagnostics(doc.uri);
+
+      // 様々な修飾子を持つメソッドでも構文エラーが発生しないことを確認
+      const syntaxErrors = diagnostics.filter(
+        (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
+      );
+      strictEqual(syntaxErrors.length, 0, '様々なメソッド修飾子で構文エラーが発生しないべきです');
+    });
+  });
+
+  describe('複雑な構文の処理', () => {
+    it('クロージャとGStringを含むコードが正しく解析される', async () => {
+      const code = `
+        class ClosureExample {
+          def list = [1, 2, 3, 4, 5]
+          
+          def processData() {
+            def evenNumbers = list.findAll { it % 2 == 0 }
+            
+            list.each { item ->
+              println "Item: \$item"
+            }
+            
+            def multiplier = { factor ->
+              return { number -> number * factor }
+            }
+            
+            def triple = multiplier(3)
+            println triple(10)
+          }
+          
+          def multilineString = """
+            This is a multiline
+            GString with \${list.size()} items
+          """
+        }
+      `;
+
+      doc = await openDoc(code, 'groovy');
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const diagnostics = languages.getDiagnostics(doc.uri);
+
+      // クロージャやGStringを含む複雑な構文でもエラーが発生しないことを確認
+      const syntaxErrors = diagnostics.filter(
+        (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
+      );
+      strictEqual(syntaxErrors.length, 0, 'クロージャとGStringを含むコードで構文エラーが発生しないべきです');
+    });
+
+    it('Groovy特有の構文（プロパティアクセス、安全参照演算子など）が正しく解析される', async () => {
+      const code = `
+        class GroovyFeatures {
+          String name
+          int age
+          
+          def testFeatures() {
+            // プロパティアクセス
+            this.name = "John"
+            
+            // 安全参照演算子
+            def length = name?.length()
+            
+            // エルビス演算子
+            def defaultName = name ?: "Unknown"
+            
+            // スプレッド演算子
+            def numbers = [1, 2, 3]
+            def doubled = numbers*.multiply(2)
+            
+            // 範囲演算子
+            def range = 1..10
+            
+            // 正規表現
+            def pattern = ~/[a-zA-Z]+/
+            
+            // マップリテラル
+            def map = [key1: 'value1', key2: 'value2']
+          }
+        }
+      `;
+
+      doc = await openDoc(code, 'groovy');
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+
+      const diagnostics = languages.getDiagnostics(doc.uri);
+
+      // Groovy特有の構文でもエラーが発生しないことを確認
+      const syntaxErrors = diagnostics.filter(
+        (d) => d.source === 'groovy-syntax' && d.severity === DiagnosticSeverity.Error,
+      );
+      strictEqual(syntaxErrors.length, 0, 'Groovy特有の構文で構文エラーが発生しないべきです');
+    });
+  });
+});

--- a/vscode-extension/src/test/suite/index.ts
+++ b/vscode-extension/src/test/suite/index.ts
@@ -10,7 +10,7 @@ export async function run(): Promise<void> {
   const mocha = new Mocha({
     ui: 'bdd',
     color: true,
-    timeout: 60000,
+    timeout: 120000,
     bail: false, // エラーがあっても全テストを実行
     grep: grepPattern, // --grepオプションがあれば設定
     reporter: 'spec', // 詳細な出力

--- a/vscode-extension/src/test/suite/index.ts
+++ b/vscode-extension/src/test/suite/index.ts
@@ -39,11 +39,11 @@ export async function run(): Promise<void> {
       }
     });
 
-    // タイムアウト対策: 60秒でテストを強制終了
+    // タイムアウト対策: 90秒でテストを強制終了
     const timeout = setTimeout(() => {
       runner.abort();
-      reject(new Error('Test execution timeout after 60 seconds'));
-    }, 60000);
+      reject(new Error('Test execution timeout after 90 seconds'));
+    }, 90000);
 
     runner.on('end', () => {
       clearTimeout(timeout);

--- a/vscode-extension/src/test/test-utils/lsp.ts
+++ b/vscode-extension/src/test/test-utils/lsp.ts
@@ -63,7 +63,7 @@ export async function closeDoc(doc: TextDocument): Promise<void> {
  * @param position 位置
  * @returns ホバー情報
  */
-export async function getHoverAt(doc: TextDocument, position: Position): Promise<Hover[]> {
+export async function getHoverAt(doc: TextDocument, position: Position): Promise<Hover[] | undefined> {
   return await commands.executeCommand<Hover[]>('vscode.executeHoverProvider', doc.uri, position);
 }
 
@@ -73,7 +73,7 @@ export async function getHoverAt(doc: TextDocument, position: Position): Promise
  * @param position 位置
  * @returns 補完候補リスト
  */
-export async function getCompletionsAt(doc: TextDocument, position: Position): Promise<CompletionList> {
+export async function getCompletionsAt(doc: TextDocument, position: Position): Promise<CompletionList | undefined> {
   return await commands.executeCommand<CompletionList>('vscode.executeCompletionItemProvider', doc.uri, position);
 }
 
@@ -112,7 +112,7 @@ export async function getLanguageClient(): Promise<LanguageClient | undefined> {
  * @param position 位置
  * @returns 定義の位置
  */
-export async function getDefinitionAt(doc: TextDocument, position: Position): Promise<Location[]> {
+export async function getDefinitionAt(doc: TextDocument, position: Position): Promise<Location[] | undefined> {
   return await commands.executeCommand<Location[]>('vscode.executeDefinitionProvider', doc.uri, position);
 }
 
@@ -122,7 +122,7 @@ export async function getDefinitionAt(doc: TextDocument, position: Position): Pr
  * @param position 位置
  * @returns 参照の位置リスト
  */
-export async function getReferencesAt(doc: TextDocument, position: Position): Promise<Location[]> {
+export async function getReferencesAt(doc: TextDocument, position: Position): Promise<Location[] | undefined> {
   return await commands.executeCommand<Location[]>('vscode.executeReferenceProvider', doc.uri, position);
 }
 
@@ -131,6 +131,6 @@ export async function getReferencesAt(doc: TextDocument, position: Position): Pr
  * @param query 検索クエリ
  * @returns シンボル情報リスト
  */
-export async function getWorkspaceSymbols(query: string): Promise<SymbolInformation[]> {
+export async function getWorkspaceSymbols(query: string): Promise<SymbolInformation[] | undefined> {
   return await commands.executeCommand<SymbolInformation[]>('vscode.executeWorkspaceSymbolProvider', query);
 }


### PR DESCRIPTION
## 概要
issue #11「[Phase 3] M3.2: ASTの基本構築」の実装を行いました。

## 実装内容
### 1. クラス定義の認識
- `ClassInfo`ドメインモデルを作成し、クラス定義情報を管理
- クラスの種別（CLASS、INTERFACE、ENUM等）を判定
- 位置情報、メソッド、フィールド情報を保持

### 2. メソッド定義の認識  
- `MethodInfo`ドメインモデルを作成し、メソッド定義情報を管理
- パラメータ情報、戻り値型、アクセス修飾子を管理
- Spockテストメソッドの特殊な名前にも対応

### 3. 構文エラーの基本検出
- GroovyAstParserの診断情報を`DiagnosticItem`に変換
- 構文エラー、不正なインポート文などを検出
- DiagnosticUseCaseに統合し、VSCodeに表示可能に

### 4. 追加実装
- `FieldInfo`ドメインモデルでフィールド情報を管理
- `AstInfo`でAST解析結果を統合管理
- `AstAnalysisService`でGroovyAstParserとドメインモデルを接続

## テスト
- AstAnalysisServiceTest: 全機能の単体テスト（10テスト）
- DiagnosticUseCaseTest: AST解析統合テスト（2テスト追加）
- 既存の統合テストも更新し、全テスト合格を確認

## 確認事項
- [x] ビルド成功
- [x] 全テスト合格  
- [x] 静的解析（Error Prone、Spotless）合格
- [x] カバレッジ基準を満たす

🤖 Generated with [Claude Code](https://claude.ai/code)