### PR TITLE
[Phase 4] M4.1: ホバー機能の骨組み (#13)

### DIFF
--- a/lsp-core/src/main/java/com/groovylsp/application/usecase/HoverUseCase.java
+++ b/lsp-core/src/main/java/com/groovylsp/application/usecase/HoverUseCase.java
@@ -1,0 +1,61 @@
+package com.groovylsp.application.usecase;
+
+import com.groovylsp.domain.repository.TextDocumentRepository;
+import io.vavr.control.Either;
+import java.net.URI;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * ホバー情報の取得に関するユースケース
+ *
+ * <p>LSPのtextDocument/hoverリクエストを処理し、 カーソル位置の要素情報を提供します。
+ */
+@Singleton
+public class HoverUseCase {
+
+  private static final Logger logger = LoggerFactory.getLogger(HoverUseCase.class);
+
+  private final TextDocumentRepository repository;
+
+  @Inject
+  public HoverUseCase(TextDocumentRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * ホバー情報を取得
+   *
+   * @param params HoverParams
+   * @return ホバー情報、またはエラー
+   */
+  public Either<String, Hover> getHover(HoverParams params) {
+    String uri = params.getTextDocument().getUri();
+    logger.debug(
+        "ホバー情報を取得: {} at {}:{}",
+        uri,
+        params.getPosition().getLine(),
+        params.getPosition().getCharacter());
+
+    return repository
+        .findByUri(URI.create(uri))
+        .toEither(() -> "ドキュメントが見つかりません: " + uri)
+        .map(
+            document -> {
+              // 現時点では固定テキストを返す
+              var content = new MarkupContent();
+              content.setKind(MarkupKind.PLAINTEXT);
+              content.setValue("Groovy element");
+
+              var hover = new Hover();
+              hover.setContents(content);
+              return hover;
+            });
+  }
+}

--- a/lsp-core/src/main/java/com/groovylsp/infrastructure/di/ServerModule.java
+++ b/lsp-core/src/main/java/com/groovylsp/infrastructure/di/ServerModule.java
@@ -2,6 +2,7 @@ package com.groovylsp.infrastructure.di;
 
 import com.groovylsp.application.usecase.DiagnosticUseCase;
 import com.groovylsp.application.usecase.DocumentSymbolUseCase;
+import com.groovylsp.application.usecase.HoverUseCase;
 import com.groovylsp.application.usecase.TextDocumentSyncUseCase;
 import com.groovylsp.domain.repository.TextDocumentRepository;
 import com.groovylsp.domain.service.AstAnalysisService;
@@ -66,11 +67,19 @@ public class ServerModule {
 
   @Provides
   @Singleton
+  public HoverUseCase provideHoverUseCase(TextDocumentRepository repository) {
+    return new HoverUseCase(repository);
+  }
+
+  @Provides
+  @Singleton
   public GroovyTextDocumentService provideTextDocumentService(
       TextDocumentSyncUseCase syncUseCase,
       DiagnosticUseCase diagnosticUseCase,
-      DocumentSymbolUseCase documentSymbolUseCase) {
-    return new GroovyTextDocumentService(syncUseCase, diagnosticUseCase, documentSymbolUseCase);
+      DocumentSymbolUseCase documentSymbolUseCase,
+      HoverUseCase hoverUseCase) {
+    return new GroovyTextDocumentService(
+        syncUseCase, diagnosticUseCase, documentSymbolUseCase, hoverUseCase);
   }
 
   @Provides

--- a/lsp-core/src/main/java/com/groovylsp/presentation/server/GroovyLanguageServer.java
+++ b/lsp-core/src/main/java/com/groovylsp/presentation/server/GroovyLanguageServer.java
@@ -40,6 +40,9 @@ public class GroovyLanguageServer implements LanguageServer, LanguageClientAware
     // ドキュメントシンボル機能
     capabilities.setDocumentSymbolProvider(true);
 
+    // ホバー機能
+    capabilities.setHoverProvider(true);
+
     var result = new InitializeResult(capabilities);
     return CompletableFuture.completedFuture(result);
   }

--- a/lsp-core/src/main/java/com/groovylsp/presentation/server/GroovyTextDocumentService.java
+++ b/lsp-core/src/main/java/com/groovylsp/presentation/server/GroovyTextDocumentService.java
@@ -2,6 +2,7 @@ package com.groovylsp.presentation.server;
 
 import com.groovylsp.application.usecase.DiagnosticUseCase;
 import com.groovylsp.application.usecase.DocumentSymbolUseCase;
+import com.groovylsp.application.usecase.HoverUseCase;
 import com.groovylsp.application.usecase.TextDocumentSyncUseCase;
 import com.groovylsp.domain.model.DiagnosticItem;
 import com.groovylsp.domain.model.DiagnosticResult;
@@ -19,6 +20,8 @@ import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Range;
@@ -41,15 +44,18 @@ public class GroovyTextDocumentService implements TextDocumentService, LanguageC
   private final TextDocumentSyncUseCase syncUseCase;
   private final DiagnosticUseCase diagnosticUseCase;
   private final DocumentSymbolUseCase documentSymbolUseCase;
+  private final HoverUseCase hoverUseCase;
 
   @Inject
   public GroovyTextDocumentService(
       TextDocumentSyncUseCase syncUseCase,
       DiagnosticUseCase diagnosticUseCase,
-      DocumentSymbolUseCase documentSymbolUseCase) {
+      DocumentSymbolUseCase documentSymbolUseCase,
+      HoverUseCase hoverUseCase) {
     this.syncUseCase = syncUseCase;
     this.diagnosticUseCase = diagnosticUseCase;
     this.documentSymbolUseCase = documentSymbolUseCase;
+    this.hoverUseCase = hoverUseCase;
   }
 
   @Override
@@ -188,6 +194,19 @@ public class GroovyTextDocumentService implements TextDocumentService, LanguageC
                     logger.error("ドキュメントシンボルの取得に失敗しました: {}", params.getTextDocument().getUri());
                     return List.of();
                   });
+        });
+  }
+
+  @Override
+  public CompletableFuture<Hover> hover(HoverParams params) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          var result = hoverUseCase.getHover(params);
+          return result.getOrElseGet(
+              error -> {
+                logger.error("ホバー情報の取得に失敗しました: {}", error);
+                return null;
+              });
         });
   }
 }

--- a/lsp-core/src/test/java/com/groovylsp/application/usecase/HoverUseCaseTest.java
+++ b/lsp-core/src/test/java/com/groovylsp/application/usecase/HoverUseCaseTest.java
@@ -1,0 +1,118 @@
+package com.groovylsp.application.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.groovylsp.domain.model.TextDocument;
+import com.groovylsp.domain.repository.TextDocumentRepository;
+import com.groovylsp.testing.FastTest;
+import io.vavr.control.Either;
+import io.vavr.control.Option;
+import java.net.URI;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** HoverUseCaseのテスト */
+@FastTest
+class HoverUseCaseTest {
+
+  private TextDocumentRepository repository;
+  private HoverUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(TextDocumentRepository.class);
+    useCase = new HoverUseCase(repository);
+  }
+
+  @Test
+  @DisplayName("ホバー情報を正常に取得できる")
+  void getHoverSuccess() {
+    // given
+    String uri = "file:///test/Calculator.groovy";
+    String content = "class Calculator { }";
+
+    var params = new HoverParams();
+    params.setTextDocument(new TextDocumentIdentifier(uri));
+    params.setPosition(new Position(0, 10)); // Calculatorクラス名の位置
+
+    var document = new TextDocument(URI.create(uri), "groovy", 1, content);
+    when(repository.findByUri(URI.create(uri))).thenReturn(Option.of(document));
+
+    // when
+    Either<String, Hover> result = useCase.getHover(params);
+
+    // then
+    assertThat(result.isRight()).isTrue();
+    Hover hover = result.get();
+    assertThat(hover).isNotNull();
+
+    assertThat(hover.getContents().isRight()).isTrue();
+    MarkupContent contents = hover.getContents().getRight();
+    assertThat(contents.getKind()).isEqualTo(MarkupKind.PLAINTEXT);
+    assertThat(contents.getValue()).isEqualTo("Groovy element");
+  }
+
+  @Test
+  @DisplayName("ドキュメントが見つからない場合はエラーを返す")
+  void getHoverDocumentNotFound() {
+    // given
+    String uri = "file:///test/NotFound.groovy";
+
+    var params = new HoverParams();
+    params.setTextDocument(new TextDocumentIdentifier(uri));
+    params.setPosition(new Position(0, 0));
+
+    when(repository.findByUri(URI.create(uri))).thenReturn(Option.none());
+
+    // when
+    Either<String, Hover> result = useCase.getHover(params);
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).contains("ドキュメントが見つかりません: " + uri);
+  }
+
+  @Test
+  @DisplayName("異なる位置でも同じ固定テキストを返す")
+  void getHoverDifferentPositions() {
+    // given
+    String uri = "file:///test/Script.groovy";
+    String content = "def hello() { println 'Hello' }";
+
+    var document = new TextDocument(URI.create(uri), "groovy", 1, content);
+    when(repository.findByUri(URI.create(uri))).thenReturn(Option.of(document));
+
+    // 異なる位置でテスト
+    var positions =
+        new Position[] {
+          new Position(0, 0), // def
+          new Position(0, 5), // hello
+          new Position(0, 15), // println
+        };
+
+    for (Position position : positions) {
+      var params = new HoverParams();
+      params.setTextDocument(new TextDocumentIdentifier(uri));
+      params.setPosition(position);
+
+      // when
+      Either<String, Hover> result = useCase.getHover(params);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      Hover hover = result.get();
+      assertThat(hover.getContents().isRight()).isTrue();
+      MarkupContent contents = hover.getContents().getRight();
+      assertThat(contents.getValue()).isEqualTo("Groovy element");
+    }
+  }
+}

--- a/lsp-core/src/test/java/com/groovylsp/presentation/server/GroovyTextDocumentServiceTest.java
+++ b/lsp-core/src/test/java/com/groovylsp/presentation/server/GroovyTextDocumentServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.groovylsp.application.usecase.DiagnosticUseCase;
 import com.groovylsp.application.usecase.DocumentSymbolUseCase;
+import com.groovylsp.application.usecase.HoverUseCase;
 import com.groovylsp.application.usecase.TextDocumentSyncUseCase;
 import com.groovylsp.domain.model.TextDocument;
 import com.groovylsp.testing.FastTest;
@@ -34,6 +35,7 @@ class GroovyTextDocumentServiceTest {
   private TextDocumentSyncUseCase syncUseCase;
   private DiagnosticUseCase diagnosticUseCase;
   private DocumentSymbolUseCase documentSymbolUseCase;
+  private HoverUseCase hoverUseCase;
   private LanguageClient client;
 
   @BeforeEach
@@ -41,8 +43,11 @@ class GroovyTextDocumentServiceTest {
     syncUseCase = mock(TextDocumentSyncUseCase.class);
     diagnosticUseCase = mock(DiagnosticUseCase.class);
     documentSymbolUseCase = mock(DocumentSymbolUseCase.class);
+    hoverUseCase = mock(HoverUseCase.class);
     client = mock(LanguageClient.class);
-    service = new GroovyTextDocumentService(syncUseCase, diagnosticUseCase, documentSymbolUseCase);
+    service =
+        new GroovyTextDocumentService(
+            syncUseCase, diagnosticUseCase, documentSymbolUseCase, hoverUseCase);
     service.connect(client);
   }
 

--- a/vscode-extension/src/test/e2e/hover.spec.ts
+++ b/vscode-extension/src/test/e2e/hover.spec.ts
@@ -1,0 +1,115 @@
+import { ok } from 'node:assert/strict';
+import { type Hover, Position, type TextDocument, commands, extensions, window } from 'vscode';
+import { closeDoc, openDoc } from '../test-utils/lsp.ts';
+
+describe('ホバー機能のテスト', () => {
+  let doc: TextDocument;
+
+  before(async () => {
+    // 拡張機能が正しくアクティベートされているか確認
+    const extension = extensions.getExtension('groovy-lsp.groovy-lsp');
+    if (extension && !extension.isActive) {
+      await extension.activate();
+    }
+    // LSPサーバーが完全に起動するまで待つ
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+  });
+
+  afterEach(async () => {
+    if (doc) {
+      await closeDoc(doc);
+    }
+  });
+
+  it('ホバー時に固定テキスト「Groovy element」が表示される', async () => {
+    const code = `class Example {
+  def greet() {
+    println "Hello, World"
+  }
+}`;
+
+    doc = await openDoc(code, 'groovy');
+    await window.showTextDocument(doc);
+
+    // LSPサーバーがドキュメントを完全に処理するまで待つ
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // カーソルをクラス名の位置に移動
+    const position = new Position(0, 10); // Exampleの中央あたり
+
+    // ホバー情報を取得
+    const hovers = (await commands.executeCommand('vscode.executeHoverProvider', doc.uri, position)) as Hover[];
+
+    ok(hovers, 'ホバー情報が返されるべきです');
+    ok(hovers.length > 0, 'ホバー情報が1つ以上存在するべきです');
+
+    // ホバー内容を確認
+    const hover = hovers[0];
+    ok(hover.contents, 'ホバーにコンテンツが含まれるべきです');
+
+    // VSCodeのHover APIは contents の中に複数の形式を含む可能性がある
+    const foundGroovyElement = checkHoverContents(hover);
+
+    ok(foundGroovyElement, 'ホバー内容に「Groovy element」が含まれるべきです');
+  });
+
+  it('メソッド上でもホバー情報が表示される', async () => {
+    const code = `class Calculator {
+  def add(int a, int b) {
+    return a + b
+  }
+}`;
+
+    doc = await openDoc(code, 'groovy');
+    await window.showTextDocument(doc);
+
+    // メソッド名の位置
+    const position = new Position(1, 8); // addメソッドの位置
+
+    const hovers = (await commands.executeCommand('vscode.executeHoverProvider', doc.uri, position)) as Hover[];
+
+    ok(hovers && hovers.length > 0, 'メソッド上でもホバー情報が表示されるべきです');
+  });
+
+  it('変数上でもホバー情報が表示される', async () => {
+    const code = `def message = "Hello"
+println message`;
+
+    doc = await openDoc(code, 'groovy');
+    await window.showTextDocument(doc);
+
+    // 変数名の位置
+    const position = new Position(1, 10); // messageの位置
+
+    const hovers = (await commands.executeCommand('vscode.executeHoverProvider', doc.uri, position)) as Hover[];
+
+    ok(hovers && hovers.length > 0, '変数上でもホバー情報が表示されるべきです');
+  });
+});
+
+// ホバーコンテンツをチェックするヘルパー関数
+function checkHoverContents(hover: Hover): boolean {
+  let foundGroovyElement = false;
+
+  if (Array.isArray(hover.contents)) {
+    // 配列の各要素をチェック
+    for (const content of hover.contents) {
+      // VSCode MarkdownString形式
+      if (content && typeof content === 'object' && 'value' in content) {
+        const value = (content as { value: string }).value;
+        // HTMLエンティティが含まれる場合も考慮
+        if (value.includes('Groovy element') || value.includes('Groovy&nbsp;element')) {
+          foundGroovyElement = true;
+          break;
+        }
+      }
+      // プレーンテキスト形式
+      else if (typeof content === 'string' && content.includes('Groovy element')) {
+        foundGroovyElement = true;
+        break;
+      }
+    }
+  }
+
+  return foundGroovyElement;
+}


### PR DESCRIPTION
## 概要
Issue #13 に基づいて、ホバー機能の基本的な骨組みを実装しました。

## 実装内容
- HoverUseCaseの実装を追加
- GroovyTextDocumentServiceにhoverメソッドを追加
- LanguageServerにホバー機能のcapabilityを追加
- 固定テキスト「Groovy element」を表示する基本実装

## テスト
### ユニットテスト
- HoverUseCaseTest: ホバー機能のユースケースのテスト
  - ドキュメントが見つかる場合の正常系
  - ドキュメントが見つからない場合のエラー処理
  - 異なる位置でも同じ固定テキストを返すことの確認

### e2eテスト
- hover.spec.ts: VSCode拡張機能でのホバー機能のテスト
  - クラス名上でのホバー表示
  - メソッド上でのホバー表示
  - 変数上でのホバー表示

## 動作確認
✅ 手元での動作確認済み
✅ 全てのテストがパス

## 今後の展開
この基本実装を土台として、今後以下の機能を追加予定：
- AST解析に基づく詳細な型情報の表示
- JavaDocコメントの表示
- メソッドシグネチャの表示

🤖 Generated with [Claude Code](https://claude.ai/code)